### PR TITLE
Added DitchCarbon and SBTI APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,8 @@ also a significant smaller footprint compared to the shipment of an individual d
 +   [Cargobike Darmstadt](http://cargobike-darmstadt.de) *[Darmstadt, Germany]*
 +   [Rad3](https://rad3.de) *[Leipzig, Germany]*
 +   [Larry vs. Harry](https://www.larryvsharry.com) *[Copenhagen, Denmark]*
+
+### APIs and Information
++   [DitchCarbon API](https://docs.ditchcarbon.com/) *[England]*
++   [Companies taking action](https://ditchcarbon.com/free-sbti-api-access/) *[England]*
+


### PR DESCRIPTION
Added two new APIs that provide insight into Carbon Emmissions

- DitchCarbon provides API access to their dataset of company and product carbon emissions disclosures, also includes reccommended actions for each company to decarbonise
-  API access to the "companies taking action" list from SBTI